### PR TITLE
android: don't hold a reactContext reference

### DIFF
--- a/android/src/main/java/com/ianlin/RNFirebaseCrashReport/RNFirebaseCrashReportModule.java
+++ b/android/src/main/java/com/ianlin/RNFirebaseCrashReport/RNFirebaseCrashReportModule.java
@@ -9,11 +9,9 @@ import com.google.firebase.crash.FirebaseCrash;
 
 public class RNFirebaseCrashReportModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
     private final static String TAG = RNFirebaseCrashReportModule.class.getCanonicalName();
-    private static ReactApplicationContext reactContext;
 
-    public RNFirebaseCrashReportModule(ReactApplicationContext _reactContext) {
-        super(_reactContext);
-        reactContext = _reactContext;
+    public RNFirebaseCrashReportModule(ReactApplicationContext reactContext) {
+        super(reactContext);
         reactContext.addLifecycleEventListener(this);
     }
 


### PR DESCRIPTION
suggested by react-native due to it may cause memory leaks
use getApplicationContext() instead when needed.
