### PR TITLE
don't depend on specific firebase version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,6 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.firebase:firebase-core:9.2.0'
-    compile 'com.google.firebase:firebase-crash:9.2.0'
+    compile 'com.google.firebase:firebase-core:+'
+    compile 'com.google.firebase:firebase-crash:+'
 }


### PR DESCRIPTION
Android build failed after upgrading my firebase library to 9.4.0
`com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/internal/zzqf;`
